### PR TITLE
Add example for LinuxRouterLocal & LinuxRouterRemote

### DIFF
--- a/config.py.example
+++ b/config.py.example
@@ -24,4 +24,5 @@ routers = [
     CiscoRouter(host='testrouter2.core.company.com', user='xyz', password='xyz', asn=2345, acl=['user1','user2']),
     BirdRouterLocal('/var/run/bird.ctl', asn=3456),
     BirdRouterRemote('host', 'user', 'password', asn=5678, name='Hostname Bird'),
+    LinuxRouterLocal(),
     ]

--- a/config.py.example
+++ b/config.py.example
@@ -25,4 +25,5 @@ routers = [
     BirdRouterLocal('/var/run/bird.ctl', asn=3456),
     BirdRouterRemote('host', 'user', 'password', asn=5678, name='Hostname Bird'),
     LinuxRouterLocal(),
+    LinuxRouterRemote('host', 'user'),
     ]


### PR DESCRIPTION
As stated in #13 (which is already merged), this adds examples for LinuxRouterLocal and LinuxRouterRemote to config.py.example